### PR TITLE
Redirect link for "open source contributions"

### DIFF
--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -12,9 +12,9 @@ const Footer = () => (
         {" API"}
       </a>
       | Built by
-      <a href="https://github.com/apoclyps/my-dev-space/graphs/contributors">
+      <a href="https://github.com/muxer-dev">
         <FontAwesome name="github" />
-        {" open source contributions"}
+        {" open source contributions."}
       </a>
     </div>
   </div>


### PR DESCRIPTION
### What's Changed
An organisation account now exists on GitHub. Have changed the link location to reflect that.

### Technical Description
n/a